### PR TITLE
バリデーションと例外発生の修正Issues#11

### DIFF
--- a/app/controllers/flowers_controller.rb
+++ b/app/controllers/flowers_controller.rb
@@ -15,7 +15,12 @@ class FlowersController < ApplicationController
   def show
     @comments = @flower.comments
     @comment = @flower.comments.build
-    @favorite = current_user.favorites.find_by(flower_id: @flower.id)
+    # @favorite = current_user.favorites.find_by(flower_id: @flower.id)
+    if user_signed_in?
+      @favorite = current_user.favorites.find_by(flower_id: @flower.id)
+    else
+      @favorite = nil
+    end
   end
 
   # GET /flowers/new

--- a/app/javascript/stylesheets/flower.scss
+++ b/app/javascript/stylesheets/flower.scss
@@ -16,6 +16,10 @@ body {
   margin: 0;
 }
 
+ul {
+  list-style-type: none;
+}
+
 .header {
   background-color: #FFD4D4;
   height: 60px;

--- a/app/models/flower.rb
+++ b/app/models/flower.rb
@@ -8,6 +8,7 @@ class Flower < ApplicationRecord
   has_one_attached :image
 
   validates :name, presence: true, length: { maximum: 300 }
+  validates :address, presence: true
 
   geocoded_by :address
   after_validation :geocode, if: :address_changed?

--- a/app/views/comments/_edit.html.erb
+++ b/app/views/comments/_edit.html.erb
@@ -1,7 +1,9 @@
 <%= form_with(model: [flower, comment], local: false, html: { class: "comment-form" }) do |form| %>
   <% if comment.errors.any? %>
     <div id="error_explanation">
-      <h2><%= pluralize(comment.errors.count, "error") %> prohibited this comment from being saved:</h2>
+    <h2>
+      <%= t("errors.template.header", model: t("activerecord.models.flower"), count: flower.errors.count) %>
+    </h2>
       <ul>
       <% comment.errors.full_messages.each do |message| %>
         <li><%= message %></li>

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -2,8 +2,10 @@
 <%= form_with(model: [flower, comment], local: false, html: { class: "comment-form" }) do |form| %>
   <% if comment.errors.any? %>
     <div id="error_explanation">
-      <h2><%= pluralize(comment.errors.count, "error") %> prohibited this comment from being saved:</h2>
-      <ul>
+    <h2>
+    <%= t("errors.template.header", model: t("activerecord.models.flower"), count: flower.errors.count) %>
+  </h2>
+    <ul>
       <% comment.errors.full_messages.each do |message| %>
         <li><%= message %></li>
       <% end %>

--- a/app/views/flowers/_form.html.erb
+++ b/app/views/flowers/_form.html.erb
@@ -3,8 +3,9 @@
 <%= form_with(model: flower) do |form| %>
   <% if flower.errors.any? %>
     <div id="error_explanation">
-      <h2><%= pluralize(flower.errors.count, "error") %> prohibited this flower from being saved:</h2>
-
+    <h2>
+      <%= t("errors.template.header", model: t("activerecord.models.flower"), count: flower.errors.count) %>
+    </h2>
       <ul>
         <% flower.errors.each do |error| %>
           <li><%= error.full_message %></li>

--- a/app/views/flowers/show.html.erb
+++ b/app/views/flowers/show.html.erb
@@ -59,11 +59,13 @@
       </div>
 
       <div class="flower-name">
-        <% unless @flower.favorite_users == current_user %>
-          <% if @favorite.present? %>
-            <%= link_to '<i class="fa-solid fa-heart" style="color: #ffa6a6;"></i>'.html_safe, favorite_path(id: @favorite.id), method: :delete %>
-          <% else %>
-            <%= link_to '<i class="fa-regular fa-heart" style="color: #ffa6a6;"></i>'.html_safe, favorites_path(flower_id: @flower.id), method: :post %>
+        <% if user_signed_in? %>
+          <% unless @flower.favorite_users == current_user %>
+            <% if @favorite.present? %>
+              <%= link_to '<i class="fa-solid fa-heart" style="color: #ffa6a6;"></i>'.html_safe, favorite_path(id: @favorite.id), method: :delete %>
+            <% else %>
+              <%= link_to '<i class="fa-regular fa-heart" style="color: #ffa6a6;"></i>'.html_safe, favorites_path(flower_id: @flower.id), method: :post %>
+            <% end %>
           <% end %>
         <% end %>
       </div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,7 +1,25 @@
 ---
 ja:
   activerecord:
-    errors:
+    models:
+      flower: 花
+      user: ユーザー
+      comment: コメント
+    attributes:
+      flower:
+        name: 花の名前
+        description: 花の詳細
+        address: 住所
+      user:
+        name: ユーザ名
+      comment:
+        content: 内容
+  errors:
+    template:
+      header:
+        one: "%{model}に%{count}件のエラーがこの%{model}の保存を禁止しました:"
+        other: "%{model}に%{count}件のエラーがこの%{model}の保存を禁止しました:"
+      body: 次の項目を確認してください
       messages:
         record_invalid: 'バリデーションに失敗しました: %{errors}'
         restrict_dependent_destroy:


### PR DESCRIPTION
- [x] 新規投稿時に500エラーが発生する状態をバリデーションエラーのメッセージが表示されるように修正
- [x] ログインしていない状態で、投稿一覧画面で、任意の花の投稿の「表示」をクリックすると、500エラーのページが表示されたため、詳細画面が表示されるよう修正
