### PR TITLE
コメントのフラッシュメッセージの修正issues#7

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -5,14 +5,22 @@ class CommentsController < ApplicationController
   def create
     @comment = @flower.comments.build(comment_params)
     @comment.user = current_user
+
+    if @comment.save
+      flash[:success] = 'コメントが投稿されました'
+    else
+      flash[:notice] = 'コメントを投稿できませんでした...'
+    end
+
     respond_to do |format|
       if @comment.save
         format.js { render :index }
       else
-        format.html { redirect_to flower_path(@flower), notice: '投稿できませんでした...' }
+        format.html { redirect_to flower_path(@flower) }
       end
     end
   end
+
   def edit
     @comment = @flower.comments.find(params[:id])
     respond_to do |format|

--- a/app/views/comments/create.js.erb
+++ b/app/views/comments/create.js.erb
@@ -1,0 +1,10 @@
+<% if flash[:notice] %>
+  $('#flash-message').html('<%= j render partial: "shared/flash", locals: { flash: flash } %>');
+<% else %>
+  $('#flash-message').empty();
+<% end %>
+
+// コメントが正常に保存された場合、フラッシュメッセージを消す
+<% if @comment.errors.blank? %>
+  $('#flash-message').empty();
+<% end %>

--- a/app/views/comments/index.js.erb
+++ b/app/views/comments/index.js.erb
@@ -1,3 +1,4 @@
 $("#comments_area").html("<%= j(render 'comments/index', { comments: @comment.flower.comments, flower: @comment.flower }) %>");
 $("textarea").val('');
 $("#notice").html("<%= j flash[:notice] %>");
+$("#success").html("<%= j flash[:success] %>");

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -31,15 +31,17 @@
       </div>
     </header>
 
-    <div class="content">
+  <div class="content">
+    <div id="success"><%= flash[:success] %>
       <% if notice %>
-          <p class="alert alert-notice"><%= notice %></p>
-        <% end %>
-        <% if alert %>
-          <p class="alert alert-error"><%= alert %></p>
-        <% end %>
-      <%= yield %>
+        <p class="alert alert-notice"><%= notice %></p>
+      <% end %>
+      <% if alert %>
+        <p class="alert alert-error"><%= alert %></p>
+      <% end %>
     </div>
+    <%= yield %>
+  </div>
 
     <footer class ="footer">
       <%= link_to "トップページへ", tops_path, class: 'footer-link' %>


### PR DESCRIPTION
コメントを空白にして投稿したときに、適切なフラッシュメッセージの内容が表示
その後に続けてコメントを正しく入力した際に、フラッシュメッセージが「投稿できませんでした...」のままになる不具合の修正